### PR TITLE
[FE-15310] Allow bypassing createTables dependence on previous detectColumnTypes call

### DIFF
--- a/dist/browser-connector.js
+++ b/dist/browser-connector.js
@@ -827,12 +827,13 @@ var DbCon = /*#__PURE__*/function () {
     _defineProperty(this, "getFields", this.callbackify("getFieldsAsync", 1));
 
     _defineProperty(this, "createTableAsync", this.handleErrors(this.wrapThrift("create_table", this.overAllClients, function (_ref13) {
-      var _ref14 = _slicedToArray(_ref13, 3),
+      var _ref14 = _slicedToArray(_ref13, 4),
           tableName = _ref14[0],
           rowDescObj = _ref14[1],
-          createParams = _ref14[2];
+          createParams = _ref14[2],
+          options = _ref14[3];
 
-      return [tableName, _helpers__WEBPACK_IMPORTED_MODULE_8__/* .mutateThriftRowDesc */ .HP(rowDescObj, _this2.importerRowDesc), createParams];
+      return [tableName, (options === null || options === void 0 ? void 0 : options.useUnmodifiedRowDesc) ? rowDescObj : _helpers__WEBPACK_IMPORTED_MODULE_8__/* .mutateThriftRowDesc */ .HP(rowDescObj, _this2.importerRowDesc), createParams];
     })));
 
     _defineProperty(this, "createTable", this.callbackify("createTableAsync", 4));

--- a/dist/node-connector.js
+++ b/dist/node-connector.js
@@ -845,12 +845,13 @@ var DbCon = /*#__PURE__*/function () {
     _defineProperty(this, "getFields", this.callbackify("getFieldsAsync", 1));
 
     _defineProperty(this, "createTableAsync", this.handleErrors(this.wrapThrift("create_table", this.overAllClients, function (_ref13) {
-      var _ref14 = _slicedToArray(_ref13, 3),
+      var _ref14 = _slicedToArray(_ref13, 4),
           tableName = _ref14[0],
           rowDescObj = _ref14[1],
-          createParams = _ref14[2];
+          createParams = _ref14[2],
+          options = _ref14[3];
 
-      return [tableName, _helpers__WEBPACK_IMPORTED_MODULE_8__/* .mutateThriftRowDesc */ .HP(rowDescObj, _this2.importerRowDesc), createParams];
+      return [tableName, (options === null || options === void 0 ? void 0 : options.useUnmodifiedRowDesc) ? rowDescObj : _helpers__WEBPACK_IMPORTED_MODULE_8__/* .mutateThriftRowDesc */ .HP(rowDescObj, _this2.importerRowDesc), createParams];
     })));
 
     _defineProperty(this, "createTable", this.callbackify("createTableAsync", 4));

--- a/src/heavy-con-es6.js
+++ b/src/heavy-con-es6.js
@@ -1622,6 +1622,10 @@ export class DbCon {
    * @param {String} tableName The name of the new table.
    * @param {Array<TColumnType>} rowDescObj Fields in the new table.
    * @param {TCreateParams} createParams Properties to apply to the new table (e.g. replicated)
+   * @param {Object} options
+   * @param {boolean} options.useUnmodifiedRowDesc By default, createTableAsync calls createTable using properties from
+   * both rowDescObj and the descriptor last returned by detectColumnTypesAsync. If true, this simply calls createTable
+   * with the passed rowDescObj, removing the dependence on the previous detectColumnTypesAsync call
    * @return {Promise.<undefined>} Generates an error if unsuccessful, or returns undefined if successful.
    *
    * @example <caption>Create a new table:</caption>
@@ -1633,9 +1637,9 @@ export class DbCon {
     this.wrapThrift(
       "create_table",
       this.overAllClients,
-      ([tableName, rowDescObj, createParams]) => [
+      ([tableName, rowDescObj, createParams, options]) => [
         tableName,
-        helpers.mutateThriftRowDesc(rowDescObj, this.importerRowDesc),
+        options?.useUnmodifiedRowDesc ? rowDescObj : helpers.mutateThriftRowDesc(rowDescObj, this.importerRowDesc),
         createParams
       ]
     )


### PR DESCRIPTION
When creating a table, we actually use the result from the last detectColumnTypes call--we pass a full rowDescObj to createTableAsync, but it's only used to mutate the previous result. Table imports from Postgres/ODBC use row descriptors fetched from the webserver instead of calling detectColumnTypes from connector, so this adds an option to just pass the full rowDescObj to createTable.