### PR TITLE
[FE-17782] Allow connecting if some connections fail + add connection timeout

### DIFF
--- a/dist/browser-connector.js
+++ b/dist/browser-connector.js
@@ -1108,7 +1108,7 @@ var DbCon = /*#__PURE__*/function () {
       clients = this._client; // Reset the client property, so we can add only the ones that we can connect to below
 
       this._client = [];
-      return Promise.all(clients.map(function (client, h) {
+      return Promise.allSettled(clients.map(function (client, h) {
         return client.connect(_this3._user[h], _this3._password[h], _this3._dbName[h]).then(function (sessionId) {
           _this3._client.push(client);
 
@@ -1116,7 +1116,15 @@ var DbCon = /*#__PURE__*/function () {
 
           return null;
         });
-      })).then(function () {
+      })).then(function (results) {
+        var successfulConnections = results.filter(function (result) {
+          return result.status === "fulfilled";
+        });
+
+        if (successfulConnections.length === 0) {
+          return Promise.reject("Failed to connect to any servers.");
+        }
+
         return _this3;
       });
     }

--- a/dist/browser-connector.js
+++ b/dist/browser-connector.js
@@ -930,6 +930,7 @@ var DbCon = /*#__PURE__*/function () {
     this._port = null;
     this._dbName = null;
     this._client = null;
+    this._connectionTimeout = null;
     this._sessionId = null;
     this._protocol = null;
     this._disableAutoReconnect = false;
@@ -1059,6 +1060,34 @@ var DbCon = /*#__PURE__*/function () {
       return this;
     }
     /**
+     * Rejects the passed promise if timeout is exceeded
+     *
+     * @param {Promise} promise - The promise to wrap with a timeout.
+     * @param {number} timeout - The time in milliseconds after which the promise will be rejected if not settled.
+     * @return {Promise} A new promise that resolves with the original promise's value, or rejects with an error if the original promise rejects or if the timeout is reached.
+     */
+
+  }, {
+    key: "wrapTimeout",
+    value: function wrapTimeout(promise, timeout) {
+      if (timeout === null) {
+        return promise;
+      }
+
+      return new Promise(function (resolve, reject) {
+        var timer = setTimeout(function () {
+          return reject(new Error("Timed out"));
+        }, timeout);
+        promise.then(function (result) {
+          clearTimeout(timer);
+          resolve(result);
+        })["catch"](function (err) {
+          clearTimeout(timer);
+          reject(err);
+        });
+      });
+    }
+    /**
      * Create a connection to the MapD server, generating a client and session ID.
      * @return {Promise.DbCon} Object.
      *
@@ -1109,7 +1138,7 @@ var DbCon = /*#__PURE__*/function () {
 
       this._client = [];
       return Promise.allSettled(clients.map(function (client, h) {
-        return client.connect(_this3._user[h], _this3._password[h], _this3._dbName[h]).then(function (sessionId) {
+        return _this3.wrapTimeout(client.connect(_this3._user[h], _this3._password[h], _this3._dbName[h]), _this3._connectionTimeout).then(function (sessionId) {
           _this3._client.push(client);
 
           _this3._sessionId.push(sessionId);
@@ -1391,6 +1420,25 @@ var DbCon = /*#__PURE__*/function () {
       }
 
       this._dbName = arrayify(_dbName);
+      return this;
+    }
+    /**
+     * Gets or sets a timeout for connection attempts. If any connections do not succeed
+     * within the specified timeout period, they will be rejected. Successful connections
+     * that complete before the timeout will remain unaffected.
+     *
+     * @param {number} timeout - The time in milliseconds after which any unfulfilled connection attempts will be rejected.
+     * @return {number|DbCon} - The connection timeout or connector itself.
+     */
+
+  }, {
+    key: "connectionTimeout",
+    value: function connectionTimeout(timeout) {
+      if (!arguments.length) {
+        return this._connectionTimeout;
+      }
+
+      this._connectionTimeout = timeout;
       return this;
     }
     /**

--- a/dist/browser-connector.js
+++ b/dist/browser-connector.js
@@ -1154,6 +1154,10 @@ var DbCon = /*#__PURE__*/function () {
           return Promise.reject("Failed to connect to any servers.");
         }
 
+        if (successfulConnections.length < clients.length) {
+          console.error("Some connections did not succeed");
+        }
+
         return _this3;
       });
     }

--- a/dist/browser-connector.js
+++ b/dist/browser-connector.js
@@ -1429,6 +1429,16 @@ var DbCon = /*#__PURE__*/function () {
      *
      * @param {number} timeout - The time in milliseconds after which any unfulfilled connection attempts will be rejected.
      * @return {number|DbCon} - The connection timeout or connector itself.
+     *
+     * @example <caption>Connect to a server with a timeout:</caption>
+     * var con = new DbCon()
+     *   .host('localhost')
+     *   .port('8080')
+     *   .dbName('myDatabase')
+     *   .user('foo')
+     *   .password('bar')
+     *   .connectionTimeout(2000)
+     *   .connect()
      */
 
   }, {

--- a/dist/node-connector.js
+++ b/dist/node-connector.js
@@ -1126,7 +1126,7 @@ var DbCon = /*#__PURE__*/function () {
       clients = this._client; // Reset the client property, so we can add only the ones that we can connect to below
 
       this._client = [];
-      return Promise.all(clients.map(function (client, h) {
+      return Promise.allSettled(clients.map(function (client, h) {
         return client.connect(_this3._user[h], _this3._password[h], _this3._dbName[h]).then(function (sessionId) {
           _this3._client.push(client);
 
@@ -1134,7 +1134,15 @@ var DbCon = /*#__PURE__*/function () {
 
           return null;
         });
-      })).then(function () {
+      })).then(function (results) {
+        var successfulConnections = results.filter(function (result) {
+          return result.status === "fulfilled";
+        });
+
+        if (successfulConnections.length === 0) {
+          return Promise.reject("Failed to connect to any servers.");
+        }
+
         return _this3;
       });
     }

--- a/dist/node-connector.js
+++ b/dist/node-connector.js
@@ -1172,6 +1172,10 @@ var DbCon = /*#__PURE__*/function () {
           return Promise.reject("Failed to connect to any servers.");
         }
 
+        if (successfulConnections.length < clients.length) {
+          console.error("Some connections did not succeed");
+        }
+
         return _this3;
       });
     }

--- a/dist/node-connector.js
+++ b/dist/node-connector.js
@@ -948,6 +948,7 @@ var DbCon = /*#__PURE__*/function () {
     this._port = null;
     this._dbName = null;
     this._client = null;
+    this._connectionTimeout = null;
     this._sessionId = null;
     this._protocol = null;
     this._disableAutoReconnect = false;
@@ -1077,6 +1078,34 @@ var DbCon = /*#__PURE__*/function () {
       return this;
     }
     /**
+     * Rejects the passed promise if timeout is exceeded
+     *
+     * @param {Promise} promise - The promise to wrap with a timeout.
+     * @param {number} timeout - The time in milliseconds after which the promise will be rejected if not settled.
+     * @return {Promise} A new promise that resolves with the original promise's value, or rejects with an error if the original promise rejects or if the timeout is reached.
+     */
+
+  }, {
+    key: "wrapTimeout",
+    value: function wrapTimeout(promise, timeout) {
+      if (timeout === null) {
+        return promise;
+      }
+
+      return new Promise(function (resolve, reject) {
+        var timer = setTimeout(function () {
+          return reject(new Error("Timed out"));
+        }, timeout);
+        promise.then(function (result) {
+          clearTimeout(timer);
+          resolve(result);
+        })["catch"](function (err) {
+          clearTimeout(timer);
+          reject(err);
+        });
+      });
+    }
+    /**
      * Create a connection to the MapD server, generating a client and session ID.
      * @return {Promise.DbCon} Object.
      *
@@ -1127,7 +1156,7 @@ var DbCon = /*#__PURE__*/function () {
 
       this._client = [];
       return Promise.allSettled(clients.map(function (client, h) {
-        return client.connect(_this3._user[h], _this3._password[h], _this3._dbName[h]).then(function (sessionId) {
+        return _this3.wrapTimeout(client.connect(_this3._user[h], _this3._password[h], _this3._dbName[h]), _this3._connectionTimeout).then(function (sessionId) {
           _this3._client.push(client);
 
           _this3._sessionId.push(sessionId);
@@ -1409,6 +1438,25 @@ var DbCon = /*#__PURE__*/function () {
       }
 
       this._dbName = arrayify(_dbName);
+      return this;
+    }
+    /**
+     * Gets or sets a timeout for connection attempts. If any connections do not succeed
+     * within the specified timeout period, they will be rejected. Successful connections
+     * that complete before the timeout will remain unaffected.
+     *
+     * @param {number} timeout - The time in milliseconds after which any unfulfilled connection attempts will be rejected.
+     * @return {number|DbCon} - The connection timeout or connector itself.
+     */
+
+  }, {
+    key: "connectionTimeout",
+    value: function connectionTimeout(timeout) {
+      if (!arguments.length) {
+        return this._connectionTimeout;
+      }
+
+      this._connectionTimeout = timeout;
       return this;
     }
     /**

--- a/dist/node-connector.js
+++ b/dist/node-connector.js
@@ -1447,6 +1447,16 @@ var DbCon = /*#__PURE__*/function () {
      *
      * @param {number} timeout - The time in milliseconds after which any unfulfilled connection attempts will be rejected.
      * @return {number|DbCon} - The connection timeout or connector itself.
+     *
+     * @example <caption>Connect to a server with a timeout:</caption>
+     * var con = new DbCon()
+     *   .host('localhost')
+     *   .port('8080')
+     *   .dbName('myDatabase')
+     *   .user('foo')
+     *   .password('bar')
+     *   .connectionTimeout(2000)
+     *   .connect()
      */
 
   }, {

--- a/src/heavy-con-es6.js
+++ b/src/heavy-con-es6.js
@@ -491,6 +491,10 @@ export class DbCon {
         return Promise.reject("Failed to connect to any servers.")
       }
 
+      if (successfulConnections.length < clients.length) {
+        console.error("Some connections did not succeed")
+      }
+
       return this
     })
   }

--- a/src/heavy-con-es6.js
+++ b/src/heavy-con-es6.js
@@ -444,7 +444,7 @@ export class DbCon {
 
     // Reset the client property, so we can add only the ones that we can connect to below
     this._client = []
-    return Promise.all(
+    return Promise.allSettled(
       clients.map((client, h) =>
         client
           .connect(this._user[h], this._password[h], this._dbName[h])
@@ -454,7 +454,16 @@ export class DbCon {
             return null
           })
       )
-    ).then(() => this)
+    ).then((results) => {
+      const successfulConnections = results.filter(
+        (result) => result.status === "fulfilled"
+      )
+      if (successfulConnections.length === 0) {
+        return Promise.reject("Failed to connect to any servers.")
+      }
+
+      return this
+    })
   }
 
   /**

--- a/src/heavy-con-es6.js
+++ b/src/heavy-con-es6.js
@@ -2037,6 +2037,16 @@ export class DbCon {
    *
    * @param {number} timeout - The time in milliseconds after which any unfulfilled connection attempts will be rejected.
    * @return {number|DbCon} - The connection timeout or connector itself.
+   *
+   * @example <caption>Connect to a server with a timeout:</caption>
+   * var con = new DbCon()
+   *   .host('localhost')
+   *   .port('8080')
+   *   .dbName('myDatabase')
+   *   .user('foo')
+   *   .password('bar')
+   *   .connectionTimeout(2000)
+   *   .connect()
    */
   connectionTimeout(timeout) {
     if (!arguments.length) {


### PR DESCRIPTION
Previously, if arrays of connection credentials were passed, the connection would reject if any of the connections returned an error. The connection should now resolve if at least one connection succeeds.

Additionally, adds `connectionTimeout` method. If any connections do not succeed within the specified timeout period, they will be rejected. Successful connections that complete before the timeout will remain unaffected.

Example usage:
```
var con = new DbCon()
  .host('localhost')
  .port('8080')
  .dbName('myDatabase')
  .user('foo')
  .password('bar')
  .connectionTimeout(2000)
  .connect()
```